### PR TITLE
Sanitize measurement id

### DIFF
--- a/rest-api/src/main/java/life/qbic/data_download/rest/exceptions/GlobalException.java
+++ b/rest-api/src/main/java/life/qbic/data_download/rest/exceptions/GlobalException.java
@@ -132,6 +132,7 @@ public class GlobalException extends RuntimeException {
    * information and avoids string matching to search for the error message.
    */
   public enum ErrorCode {
+    ILLEGAL_MEASUREMENT_ID,
     GENERAL,
     MEASUREMENT_NOT_FOUND;
 

--- a/rest-api/src/main/java/life/qbic/data_download/rest/exceptions/GlobalExceptionHandler.java
+++ b/rest-api/src/main/java/life/qbic/data_download/rest/exceptions/GlobalExceptionHandler.java
@@ -35,6 +35,7 @@ public class GlobalExceptionHandler {
     UserFriendlyErrorMessage errorMessage = errorMessageTranslationService.translate(
         globalException);
     HttpStatusCode status = switch (globalException.errorCode()) {
+      case ILLEGAL_MEASUREMENT_ID -> HttpStatus.BAD_REQUEST;
       case GENERAL -> HttpStatus.INTERNAL_SERVER_ERROR;
       case MEASUREMENT_NOT_FOUND -> HttpStatus.NOT_FOUND;
     };

--- a/rest-api/src/main/resources/exception-messages.properties
+++ b/rest-api/src/main/resources/exception-messages.properties
@@ -1,2 +1,3 @@
 GENERAL= Apologies, an error occurred! -> Looks like something went wrong! We track these errors, but if the problem persists feel free to contact us at support@qbic.zendesk.com. In the meantime, try refreshing.
 MEASUREMENT_NOT_FOUND=The measurement with ID {0} was not found.
+ILLEGAL_MEASUREMENT_ID=Illegal parameters -> Looks like the provided measurement identifier contains illegal characters.


### PR DESCRIPTION
Addresses the measurement identifier being logged. This PR sanitizes the identifier and only allows characters `A-Z`, `a-z`, `0-9` and `-` in a measurement identifier.

Addresses https://github.com/qbicsoftware/data-download-server/security/code-scanning/7